### PR TITLE
Update recipient's list whenever widget's configuration changes

### DIFF
--- a/lib/flutter_chips_selector.dart
+++ b/lib/flutter_chips_selector.dart
@@ -2,6 +2,7 @@ library flutter_chips_selector;
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -101,6 +102,15 @@ class ChipsSelectorState<T> extends State<ChipsSelector<T?>> {
       }
     };
     widget.current.addListener(_currentFocusNodeListener);
+  }
+
+  @override
+  void didUpdateWidget(covariant ChipsSelector<T?> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!listEquals(oldWidget.initialValue, widget.initialValue)) {
+      _items.replaceRange(0, _items.length, widget.initialValue);
+      _textController.clear();
+    }
   }
 
   @override


### PR DESCRIPTION
This PR resolves the issue of non-updation of recipient's list in the chip selector when [`ChipsSelector`'s](https://github.com/skalio/flutter-chips-selector/blob/31bdef9d7e14ca792bb8be1aa908bc4499ad5f56/lib/flutter_chips_selector.dart#L14)  configuration changes.