### PR TITLE
Fix focus traversal

### DIFF
--- a/lib/flutter_chips_selector.dart
+++ b/lib/flutter_chips_selector.dart
@@ -151,21 +151,23 @@ class ChipsSelectorState<T> extends State<ChipsSelector<T?>> {
                 decoration: widget.decoration?.copyWith(
                         labelStyle: TextStyle(color: widget.labelColor)) ??
                     InputDecoration(),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Container(
-                      padding: EdgeInsets.all(0),
-                      child: Wrap(
-                        spacing: 2,
-                        runSpacing: 2,
-                        alignment: WrapAlignment.start,
-                        direction: Axis.horizontal,
-                        children: _getWrapWidgets(),
+                child: FocusTraversalGroup(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Container(
+                        padding: EdgeInsets.all(0),
+                        child: Wrap(
+                          spacing: 2,
+                          runSpacing: 2,
+                          alignment: WrapAlignment.start,
+                          direction: Axis.horizontal,
+                          children: _getWrapWidgets(),
+                        ),
                       ),
-                    ),
-                    CompositedTransformTarget(link: this._layerLink),
-                  ],
+                      CompositedTransformTarget(link: this._layerLink),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/flutter_chips_selector.dart
+++ b/lib/flutter_chips_selector.dart
@@ -127,6 +127,8 @@ class ChipsSelectorState<T> extends State<ChipsSelector<T?>> {
   void dispose() {
     _textController.dispose();
     _overlayScrollController.dispose();
+    _focusableActionDetectorFocusNode.dispose();
+    _rawKeyboardListenerFocusNode.dispose();
     widget.current.removeListener(_currentFocusNodeListener);
     super.dispose();
   }


### PR DESCRIPTION
This PR addresses the issue of focus being passed to `ChipsSelector`'s `FocusableActionDetector` which is not desired during tab traversal.