### PR TITLE
Duplicate free form entry selection reset

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,7 @@ class MyWidget extends StatelessWidget {
       children: [
         const Text(
             "Type to show suggestion Overlay\nChoose with Arrow-Up and Arrow-Down or with mouse\nSelect with Enter\nRemove with Backspace\nClick Chip to remove\n\nEnter to complete and go to next focus (if no suggestion overlay open)"),
+        const Text("\n\nIn this example: Start your input with a # to get the input 1:1 as a suggestion"),
         const SizedBox(height: 40),
         ChipsSelector<String>(
           nextFocus: nextFocus,
@@ -65,14 +66,16 @@ class MyWidget extends StatelessWidget {
               ),
             );
           },
-          findSuggestions: (query) => [
-            "Chip Option 1",
-            "Chip Option 2",
-            "Chip Option 3",
-            "Chip Option 4",
-            "Chip Option 5",
-            "Chip Option 6",
-          ],
+          findSuggestions: (query) => query.startsWith("#")
+              ? [query]
+              : [
+                  "Chip Option 1",
+                  "Chip Option 2",
+                  "Chip Option 3",
+                  "Chip Option 4",
+                  "Chip Option 5",
+                  "Chip Option 6",
+                ],
           onChanged: (v) {
             // use this to sync your local state with the ChipsSelector's one
           },

--- a/lib/flutter_chips_selector.dart
+++ b/lib/flutter_chips_selector.dart
@@ -335,6 +335,10 @@ class ChipsSelectorState<T> extends State<ChipsSelector<T>> {
                         _suggestionsWithoutActiveChips =
                             _suggestionsResult.where((element) => !_activeChips.contains(element)).toList();
                         if (_suggestionsWithoutActiveChips.length > 0) {
+                          _selectedIndex = 0;
+                        } else {
+                          _selectedIndex = -1;
+                        }
                       });
                     } else {
                       _suggestionsWithoutActiveChips.clear();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: flutter_chips_selector
 description: Flutter library for building input fields that covert text input into InputChips.
-version: 0.0.9
-author: Thomas Verbeek <tv@skalio.com>
+version: 0.0.10
 homepage: https://github.com/skalio/flutter-chips-selector
 
 environment:
@@ -15,39 +14,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
 
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
There was the following edge case:

Enter a text that produces a list of suggestions
=> selected index is set to 0 of that list

Enter one more character that no longer produces a list of suggestions
(e.g. because it would be a duplicate entry)
=> selected index was not reset to -1, but instead was still 0 from before

Pressing enter would now lead to an index out of bounds error (0 index in empty list)

____

I have adjusted the example project so that we can test this case manually
( was not possible to reproduce this in the example before )

This PR does not add a new test case because of time constraints in the main project.

We should add this case soon